### PR TITLE
Issue#183 - Added name of bucket for CouchBase

### DIFF
--- a/doc/technical-manual.adoc
+++ b/doc/technical-manual.adoc
@@ -205,7 +205,8 @@ the libraries used by Python to connect to CouchBase:
     $ sudo dpkg -i libcouchbase-dev_2.5.7-1_amd64.deb
 
 The following buckets should be created:
-  - score_encoding
+
+- score_encoding
 
 [[installing-django]]
 === Installing and Configuring Django

--- a/doc/technical-manual.adoc
+++ b/doc/technical-manual.adoc
@@ -188,13 +188,13 @@ to PostgreSQL:
 [[installing-couchbase]]
 === Installing CouchBase
 
-Access http://www.couchbase.com[CouchBase website] and download CouchBase 
+Access http://www.couchbase.com[CouchBase website] and download CouchBase
 Community Edition 4.0. To install it, execute:
 
     $ sudo dpkg -i couchbase-server-community_4.0.0-ubuntu14.04_amd64.deb
-    
+
 After the installation process, access http://localhost:8091 to configure the local
-instance. Just accept all default values for development purposes. Then, install 
+instance. Just accept all default values for development purposes. Then, install
 the libraries used by Python to connect to CouchBase:
 
     $ wget http://packages.couchbase.com/clients/c/libcouchbase-2.5.7_ubuntu1404_amd64.tar
@@ -203,6 +203,9 @@ the libraries used by Python to connect to CouchBase:
     $ sudo dpkg -i libcouchbase2-core_2.5.7-1_amd64.deb
     $ sudo dpkg -i libcouchbase2-bin_2.5.7-1_amd64.deb
     $ sudo dpkg -i libcouchbase-dev_2.5.7-1_amd64.deb
+
+The following buckets should be created:
+  - score_encoding
 
 [[installing-django]]
 === Installing and Configuring Django


### PR DESCRIPTION
The technical doc should precise that the bucket should be named "score_encoding". 