### PR TITLE
#572 Renommer la traduction de "Master spécialisé" en "Master de spécialisation"

### DIFF
--- a/admission/locale/fr_BE/LC_MESSAGES/django.po
+++ b/admission/locale/fr_BE/LC_MESSAGES/django.po
@@ -1414,7 +1414,7 @@ msgid "MASTER_180_OR_240"
 msgstr "Master 180 or 240"
 
 msgid "ADVANCED_MASTER"
-msgstr "Master spécialisé"
+msgstr "Master de spécialisation"
 
 msgid "CAPAES"
 msgstr "Capaes"


### PR DESCRIPTION
Inform the ticket you are solving in this pull request: #572
