### PR TITLE
Add login as as dependency to facilitate root cause analysis in all environments

### DIFF
--- a/frontoffice/settings.py
+++ b/frontoffice/settings.py
@@ -71,7 +71,17 @@ INSTALLED_APPS = (
     'internship',
     'exam_enrollment',
     'attestation',
+    'loginas'
 )
+
+# Authentication configuration
+
+LOGINAS_REDIRECT_URL = "/dashboard"
+
+LOGIN_URL=reverse_lazy('login')
+OVERRIDED_LOGIN_URL = ''
+OVERRIDED_LOGOUT_URL = ''
+LOGOUT_BUTTON = True
 
 # check if we are testing right now
 TESTING = 'test' in sys.argv
@@ -266,11 +276,6 @@ QUEUES = {
     }
 }
 
-
-LOGIN_URL=reverse_lazy('login')
-OVERRIDED_LOGOUT_URL = ''
-OVERRIDED_LOGIN_URL = ''
-LOGOUT_BUTTON = True
 
 # This has to be replaced by the actual url where you institution logo can be found.
 # Ex : LOGO_INSTITUTION_URL = 'https://www.google.be/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png'

--- a/frontoffice/urls.py
+++ b/frontoffice/urls.py
@@ -63,6 +63,8 @@ if 'exam_enrollment' in settings.INSTALLED_APPS:
     urlpatterns = urlpatterns + (url(r'^exam_enrollment/', include('exam_enrollment.urls')), )
 if 'attestation' in settings.INSTALLED_APPS:
     urlpatterns = urlpatterns + (url(r'^attestation/', include('attestation.urls')), )
+if 'loginas' in settings.INSTALLED_APPS:
+    urlpatterns += url(r'^admin/', include('loginas.urls')),
 
 handler404 = 'base.views.common.page_not_found'
 handler403 = 'base.views.common.access_denied'

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,6 @@ selenium==2.48.0
 django-analytical==2.2.2
 factory-boy==2.8.1
 django-dotenv==1.4.1
+django-loginas>=0.3.1
 
 -r ./osis_common/requirements.txt


### PR DESCRIPTION
Utilise https://github.com/skorokithakis/django-loginas

Cela permettra de se faire passer pour quelqu'un. Pour le moment seuls les superusers peuvent le faire et ne peuvent pas se faire passer pour un autre superuser.