### PR TITLE
OSIS-1172: Ajout du décompte des places disponibles sur osis-portal pour les sujets dans le tableau

### DIFF
--- a/dissertation/locale/en/LC_MESSAGES/django.po
+++ b/dissertation/locale/en/LC_MESSAGES/django.po
@@ -200,6 +200,9 @@ msgstr "Next status"
 msgid "no_result"
 msgstr "No result"
 
+msgid "of"
+msgstr "of"
+
 msgid "offer_proposition"
 msgstr "Offer"
 

--- a/dissertation/locale/fr_BE/LC_MESSAGES/django.po
+++ b/dissertation/locale/fr_BE/LC_MESSAGES/django.po
@@ -200,6 +200,9 @@ msgstr "Nouveau statut"
 msgid "no_result"
 msgstr "Aucun résultat trouvé"
 
+msgid "of"
+msgstr "sur"
+
 msgid "offer_proposition"
 msgstr "Programme de cours"
 

--- a/dissertation/models/dissertation.py
+++ b/dissertation/models/dissertation.py
@@ -27,7 +27,7 @@ from osis_common.models.serializable_model import SerializableModel, Serializabl
 from django.db import models
 from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _
-from base.models import student, offer_year, academic_year
+from base.models import student, offer_year
 from dissertation.models import dissertation_location, proposition_dissertation
 from dissertation.utils import emails_dissert
 from base import models as mdl
@@ -110,7 +110,6 @@ class Dissertation(SerializableModel):
         logged_person = mdl.person.find_by_user(request.user)
         logged_student = mdl.student.find_by_person(logged_person)
         return logged_student == self.author
-
 
 
 def count_submit_by_user(user, offer):

--- a/dissertation/models/dissertation.py
+++ b/dissertation/models/dissertation.py
@@ -27,7 +27,7 @@ from osis_common.models.serializable_model import SerializableModel, Serializabl
 from django.db import models
 from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _
-from base.models import student, offer_year
+from base.models import student, offer_year, academic_year
 from dissertation.models import dissertation_location, proposition_dissertation
 from dissertation.utils import emails_dissert
 from base import models as mdl
@@ -113,8 +113,12 @@ class Dissertation(SerializableModel):
 
 
 def count_submit_by_user(user, offer):
-    return Dissertation.objects.filter(author=user).filter(offer_year_start__offer=offer)\
-        .exclude(status='DRAFT').exclude(status='DIR_KO').filter(active=True).count()
+    return Dissertation.objects.filter(author=user)\
+        .filter(offer_year_start__offer=offer) \
+        .exclude(status='DIR_KO') \
+        .exclude(status='DRAFT')\
+        .filter(active=True)\
+        .count()
 
 
 def get_next_status(memory, operation):

--- a/dissertation/models/dissertation.py
+++ b/dissertation/models/dissertation.py
@@ -112,15 +112,6 @@ class Dissertation(SerializableModel):
         return logged_student == self.author
 
 
-def count_by_proposition(subject):
-    current_academic_year = academic_year.starting_academic_year()
-    return Dissertation.objects.filter(active=True)\
-                               .filter(proposition_dissertation=subject) \
-                               .filter(offer_year_start__academic_year=current_academic_year) \
-                               .exclude(status='DRAFT') \
-                               .exclude(status='DIR_KO') \
-                               .count()
-
 
 def count_submit_by_user(user, offer):
     return Dissertation.objects.filter(author=user).filter(offer_year_start__offer=offer)\

--- a/dissertation/models/dissertation.py
+++ b/dissertation/models/dissertation.py
@@ -149,3 +149,12 @@ def find_by_user(user):
 
 def find_by_id(dissertation_id):
     return Dissertation.objects.get(pk=dissertation_id)
+
+def count_by_proposition(proposition):
+    current_academic_year = academic_year.starting_academic_year()
+    return Dissertation.objects.filter(proposition_dissertation=proposition) \
+        .filter(active=True) \
+        .filter(offer_year_start__academic_year=current_academic_year) \
+        .exclude(status='DRAFT') \
+        .exclude(status='DIR_KO') \
+        .count()

--- a/dissertation/models/dissertation.py
+++ b/dissertation/models/dissertation.py
@@ -150,6 +150,7 @@ def find_by_user(user):
 def find_by_id(dissertation_id):
     return Dissertation.objects.get(pk=dissertation_id)
 
+
 def count_by_proposition(proposition):
     current_academic_year = academic_year.starting_academic_year()
     return Dissertation.objects.filter(proposition_dissertation=proposition) \

--- a/dissertation/models/dissertation.py
+++ b/dissertation/models/dissertation.py
@@ -28,7 +28,7 @@ from django.db import models
 from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _
 from base.models import student, offer_year, academic_year
-from . import dissertation_location, proposition_dissertation
+from dissertation.models import dissertation_location, proposition_dissertation
 from dissertation.utils import emails_dissert
 from base import models as mdl
 

--- a/dissertation/models/proposition_dissertation.py
+++ b/dissertation/models/proposition_dissertation.py
@@ -23,13 +23,13 @@
 #    see http://www.gnu.org/licenses/.
 #
 ##############################################################################
+from base.models import academic_year
 from osis_common.models.serializable_model import SerializableModel, SerializableModelAdmin
 from dissertation.models import proposition_offer
 from django.db import models
 from django.db.models import Q
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
-from dissertation.models import dissertation
 
 
 class PropositionDissertationAdmin(SerializableModelAdmin):
@@ -81,8 +81,14 @@ class PropositionDissertation(SerializableModel):
         author = u"%s %s %s" % (last_name.upper(), first_name, middle_name)
         return author+" - "+str(self.title)
 
-    def get_count_use(self):
-        return dissertation.count_by_proposition(self)
+    def count_dissertations(self):
+        current_academic_year = academic_year.starting_academic_year()
+        return self.dissertation_set \
+            .filter(active=True) \
+            .filter(offer_year_start__academic_year=current_academic_year) \
+            .exclude(status='DRAFT') \
+            .exclude(status='DIR_KO') \
+            .count()
 
     class Meta:
         ordering = ["author__person__last_name", "author__person__middle_name", "author__person__first_name", "title"]

--- a/dissertation/models/proposition_dissertation.py
+++ b/dissertation/models/proposition_dissertation.py
@@ -80,7 +80,6 @@ class PropositionDissertation(SerializableModel):
         author = u"%s %s %s" % (last_name.upper(), first_name, middle_name)
         return author+" - "+str(self.title)
 
-
     class Meta:
         ordering = ["author__person__last_name", "author__person__middle_name", "author__person__first_name", "title"]
 

--- a/dissertation/models/proposition_dissertation.py
+++ b/dissertation/models/proposition_dissertation.py
@@ -29,6 +29,7 @@ from django.db import models
 from django.db.models import Q
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
+from dissertation.models import dissertation
 
 
 class PropositionDissertationAdmin(SerializableModelAdmin):
@@ -80,6 +81,9 @@ class PropositionDissertation(SerializableModel):
         author = u"%s %s %s" % (last_name.upper(), first_name, middle_name)
         return author+" - "+str(self.title)
 
+    def get_count_use(self):
+        return dissertation.count_by_proposition(self)
+
     class Meta:
         ordering = ["author__person__last_name", "author__person__middle_name", "author__person__first_name", "title"]
 
@@ -109,3 +113,5 @@ def find_by_id(proposition_id):
 def search_by_offers(offers):
     proposition_ids = proposition_offer.find_by_offers(offers).values('proposition_dissertation_id')
     return PropositionDissertation.objects.filter(pk__in=proposition_ids, active=True, visibility=True)
+
+

--- a/dissertation/models/proposition_dissertation.py
+++ b/dissertation/models/proposition_dissertation.py
@@ -113,5 +113,3 @@ def find_by_id(proposition_id):
 def search_by_offers(offers):
     proposition_ids = proposition_offer.find_by_offers(offers).values('proposition_dissertation_id')
     return PropositionDissertation.objects.filter(pk__in=proposition_ids, active=True, visibility=True)
-
-

--- a/dissertation/models/proposition_dissertation.py
+++ b/dissertation/models/proposition_dissertation.py
@@ -23,7 +23,6 @@
 #    see http://www.gnu.org/licenses/.
 #
 ##############################################################################
-from base.models import academic_year
 from osis_common.models.serializable_model import SerializableModel, SerializableModelAdmin
 from dissertation.models import proposition_offer
 from django.db import models
@@ -81,14 +80,6 @@ class PropositionDissertation(SerializableModel):
         author = u"%s %s %s" % (last_name.upper(), first_name, middle_name)
         return author+" - "+str(self.title)
 
-    def count_dissertations(self):
-        current_academic_year = academic_year.starting_academic_year()
-        return self.dissertation_set \
-            .filter(active=True) \
-            .filter(offer_year_start__academic_year=current_academic_year) \
-            .exclude(status='DRAFT') \
-            .exclude(status='DIR_KO') \
-            .count()
 
     class Meta:
         ordering = ["author__person__last_name", "author__person__middle_name", "author__person__first_name", "title"]

--- a/dissertation/templates/proposition_dissertations_list.html
+++ b/dissertation/templates/proposition_dissertations_list.html
@@ -66,7 +66,7 @@
                   <td><a href="{% url 'proposition_dissertation_detail' pk=proposition_offer.proposition_dissertation.pk %}">{{ proposition_offer.proposition_dissertation.title }}</a></td>
                   <td>{{ proposition_offer.proposition_dissertation.author }}</td>
                   <td><span class="label label-default">{{ proposition_offer.offer_proposition }}</span></td>
-                  <td>{{ proposition_offer.proposition_dissertation.count_dissertations }} {% trans 'of' %} {{ proposition_offer.proposition_dissertation.max_number_student }}</td>
+                  <td>{{ proposition_offer.proposition_dissertation.dissertations_count }} {% trans 'of' %} {{ proposition_offer.proposition_dissertation.max_number_student }}</td>
                 </tr>
               {% endfor %}
             </table>

--- a/dissertation/templates/proposition_dissertations_list.html
+++ b/dissertation/templates/proposition_dissertations_list.html
@@ -66,7 +66,7 @@
                   <td><a href="{% url 'proposition_dissertation_detail' pk=proposition_offer.proposition_dissertation.pk %}">{{ proposition_offer.proposition_dissertation.title }}</a></td>
                   <td>{{ proposition_offer.proposition_dissertation.author }}</td>
                   <td><span class="label label-default">{{ proposition_offer.offer_proposition }}</span></td>
-                  <td>{{ proposition_offer.proposition_dissertation.get_count_use }} {% trans 'of' %} {{ proposition_offer.proposition_dissertation.max_number_student }}</td>
+                  <td>{{ proposition_offer.proposition_dissertation.count_dissertations }} {% trans 'of' %} {{ proposition_offer.proposition_dissertation.max_number_student }}</td>
                 </tr>
               {% endfor %}
             </table>

--- a/dissertation/templates/proposition_dissertations_list.html
+++ b/dissertation/templates/proposition_dissertations_list.html
@@ -66,7 +66,7 @@
                   <td><a href="{% url 'proposition_dissertation_detail' pk=proposition_offer.proposition_dissertation.pk %}">{{ proposition_offer.proposition_dissertation.title }}</a></td>
                   <td>{{ proposition_offer.proposition_dissertation.author }}</td>
                   <td><span class="label label-default">{{ proposition_offer.offer_proposition }}</span></td>
-                  <td>{{ proposition_offer.proposition_dissertation.max_number_student }}</td>
+                  <td>{{ proposition_offer.proposition_dissertation.get_count_use }} {% trans 'of' %} {{ proposition_offer.proposition_dissertation.max_number_student }}</td>
                 </tr>
               {% endfor %}
             </table>

--- a/dissertation/tests/models/test_dissertation.py
+++ b/dissertation/tests/models/test_dissertation.py
@@ -69,7 +69,7 @@ class DissertationModelTestCase(TestCase):
                                                                        title='Proposition de memoire'
                                                                        )
 
-    def test_count_by_proposition(self):
+    def test_count_dissertations(self):
         self.client.force_login(self.manager.person.user)
         self.dissertation_test_count2015 = DissertationFactory(author=self.student1,
                                                                offer_year_start=self.offer_year_start2015,

--- a/dissertation/tests/models/test_dissertation.py
+++ b/dissertation/tests/models/test_dissertation.py
@@ -34,7 +34,8 @@ from base.tests.factories.offer_enrollment import OfferEnrollmentFactory
 from dissertation.tests.factories.adviser import AdviserManagerFactory, AdviserTeacherFactory
 from dissertation.tests.factories.dissertation import DissertationFactory
 from dissertation.tests.factories.proposition_dissertation import PropositionDissertationFactory
-from dissertation.models import dissertation
+from dissertation.models import dissertation, proposition_dissertation
+
 
 class DissertationModelTestCase(TestCase):
     def setUp(self):
@@ -86,5 +87,5 @@ class DissertationModelTestCase(TestCase):
                                                                dissertation_role__adviser=self.teacher,
                                                                dissertation_role__status='PROMOTEUR')
 
-        self.assertEqual(dissertation.count_dissertations(self.proposition_dissertation),1)
+        self.assertEqual(proposition_dissertation.count_dissertations(self.proposition_dissertation),1)
 

--- a/dissertation/tests/models/test_dissertation.py
+++ b/dissertation/tests/models/test_dissertation.py
@@ -31,6 +31,7 @@ from base.tests.factories.person import PersonFactory
 from base.tests.factories.offer import OfferFactory
 from base.tests.factories.student import StudentFactory
 from base.tests.factories.offer_enrollment import OfferEnrollmentFactory
+from dissertation.models import dissertation
 from dissertation.models.proposition_dissertation import PropositionDissertation
 from dissertation.tests.factories.adviser import AdviserManagerFactory, AdviserTeacherFactory
 from dissertation.tests.factories.dissertation import DissertationFactory
@@ -70,7 +71,7 @@ class DissertationModelTestCase(TestCase):
                                                                        title='Proposition de memoire'
                                                                        )
 
-    def test_count_dissertations(self):
+    def test_count_by_proposition(self):
         self.client.force_login(self.manager.person.user)
         self.dissertation_test_count2015 = DissertationFactory(author=self.student1,
                                                                offer_year_start=self.offer_year_start2015,
@@ -88,4 +89,4 @@ class DissertationModelTestCase(TestCase):
                                                                dissertation_role__adviser=self.teacher,
                                                                dissertation_role__status='PROMOTEUR')
 
-        self.assertEqual(PropositionDissertation.count_dissertations(self.proposition_dissertation), 1)
+        self.assertEqual(dissertation.count_by_proposition(self.proposition_dissertation), 1)

--- a/dissertation/tests/models/test_dissertation.py
+++ b/dissertation/tests/models/test_dissertation.py
@@ -33,7 +33,6 @@ from base.tests.factories.student import StudentFactory
 from base.tests.factories.offer_enrollment import OfferEnrollmentFactory
 from dissertation.tests.factories.adviser import AdviserManagerFactory, AdviserTeacherFactory
 from dissertation.tests.factories.dissertation import DissertationFactory
-from dissertation.tests.factories.offer_proposition import OfferPropositionFactory
 from dissertation.tests.factories.proposition_dissertation import PropositionDissertationFactory
 from dissertation.models import dissertation
 
@@ -87,5 +86,5 @@ class DissertationModelTestCase(TestCase):
                                                                dissertation_role__adviser=self.teacher,
                                                                dissertation_role__status='PROMOTEUR')
 
-        self.assertEqual(dissertation.count_by_proposition(self.proposition_dissertation),1)
+        self.assertEqual(dissertation.count_dissertations(self.proposition_dissertation),1)
 

--- a/dissertation/tests/models/test_dissertation.py
+++ b/dissertation/tests/models/test_dissertation.py
@@ -31,10 +31,11 @@ from base.tests.factories.person import PersonFactory
 from base.tests.factories.offer import OfferFactory
 from base.tests.factories.student import StudentFactory
 from base.tests.factories.offer_enrollment import OfferEnrollmentFactory
+from dissertation.models.proposition_dissertation import PropositionDissertation
 from dissertation.tests.factories.adviser import AdviserManagerFactory, AdviserTeacherFactory
 from dissertation.tests.factories.dissertation import DissertationFactory
 from dissertation.tests.factories.proposition_dissertation import PropositionDissertationFactory
-from dissertation.models import dissertation, proposition_dissertation
+
 
 
 class DissertationModelTestCase(TestCase):
@@ -87,5 +88,4 @@ class DissertationModelTestCase(TestCase):
                                                                dissertation_role__adviser=self.teacher,
                                                                dissertation_role__status='PROMOTEUR')
 
-        self.assertEqual(proposition_dissertation.count_dissertations(self.proposition_dissertation),1)
-
+        self.assertEqual(PropositionDissertation.count_dissertations(self.proposition_dissertation), 1)

--- a/dissertation/views/proposition_dissertation.py
+++ b/dissertation/views/proposition_dissertation.py
@@ -46,9 +46,11 @@ def proposition_dissertations(request):
                           'proposition_offers': proposition_offers,
                           'student': student})
 
+
 def _append_dissertations_count(prop_offer):
     prop_offer.proposition_dissertation.dissertations_count = dissertation.count_by_proposition(prop_offer.proposition_dissertation)
     return prop_offer
+
 
 @login_required
 def proposition_dissertation_detail(request, pk):

--- a/dissertation/views/proposition_dissertation.py
+++ b/dissertation/views/proposition_dissertation.py
@@ -39,12 +39,16 @@ def proposition_dissertations(request):
     student = mdl.student.find_by_person(person)
     offers = mdl.offer.find_by_student(student)
     proposition_offers = proposition_offer.find_by_offers_ordered_by_proposition_dissertation(offers)
+    proposition_offers = [_append_dissertations_count(prop_offer) for prop_offer in proposition_offers]
     date_now = timezone.now().date()
     return layout.render(request, 'proposition_dissertations_list.html',
                          {'date_now': date_now,
                           'proposition_offers': proposition_offers,
                           'student': student})
 
+def _append_dissertations_count(prop_offer):
+    prop_offer.proposition_dissertation.dissertations_count = dissertation.count_by_proposition(prop_offer.proposition_dissertation)
+    return prop_offer
 
 @login_required
 def proposition_dissertation_detail(request, pk):
@@ -53,7 +57,7 @@ def proposition_dissertation_detail(request, pk):
     offer_propositions = proposition_offer.search_by_proposition_dissertation(subject)
     person = mdl.person.find_by_user(request.user)
     student = mdl.student.find_by_person(person)
-    using = proposition.count_dissertations()
+    using = dissertation.count_by_proposition(proposition)
     percent = using * 100 / subject.max_number_student if subject.max_number_student else 0
     count_proposition_role = proposition_role.count_by_proposition(subject)
     files = proposition_document_file.find_by_proposition(subject)

--- a/dissertation/views/proposition_dissertation.py
+++ b/dissertation/views/proposition_dissertation.py
@@ -48,7 +48,8 @@ def proposition_dissertations(request):
 
 
 def _append_dissertations_count(prop_offer):
-    prop_offer.proposition_dissertation.dissertations_count = dissertation.count_by_proposition(prop_offer.proposition_dissertation)
+    prop_offer.proposition_dissertation.dissertations_count = \
+        dissertation.count_by_proposition(prop_offer.proposition_dissertation)
     return prop_offer
 
 

--- a/dissertation/views/proposition_dissertation.py
+++ b/dissertation/views/proposition_dissertation.py
@@ -48,11 +48,12 @@ def proposition_dissertations(request):
 
 @login_required
 def proposition_dissertation_detail(request, pk):
+    proposition = proposition_dissertation.find_by_id(pk)
     subject = get_object_or_404(proposition_dissertation.PropositionDissertation, pk=pk)
     offer_propositions = proposition_offer.search_by_proposition_dissertation(subject)
     person = mdl.person.find_by_user(request.user)
     student = mdl.student.find_by_person(person)
-    using = dissertation.count_by_proposition(subject)
+    using = proposition.count_dissertations()
     percent = using * 100 / subject.max_number_student if subject.max_number_student else 0
     count_proposition_role = proposition_role.count_by_proposition(subject)
     files = proposition_document_file.find_by_proposition(subject)


### PR DESCRIPTION
Référence Jira : OSIS-1172

Ajout du décompte des places disponibles sur osis-portal pour les sujets dans le tableau

Vérifier les points suivants : 
- [ ] Ouvrir une release task Jira si le ticket génère une tâche pour la release : 
    - modification de configuration
    - table à synchroniser en entier, etc.
- [ ] Uniformiser les modèles osis avec les changements effectués dans osis-portal si nécessaire
- [ ] Permissions et droits d’accès mettre à jour la documentation si : 
    - on rajoute/modifie une permission
    - on rajoute/modifie un groupe d’utilisateurs, etc.
