### PR TITLE
[hotfix/OSIS-8461 => QA] Les barres de progression ne sont pas visibles si le PAE est vide

### DIFF
--- a/inscription_aux_cours/templates/inscription_aux_cours/cours/recapitulatif.html
+++ b/inscription_aux_cours/templates/inscription_aux_cours/cours/recapitulatif.html
@@ -99,6 +99,9 @@
 
                 {% include "inscription_aux_cours/cours/blocks/proposition_programme_annuel_etudiant.html" %}
             {% else %}
+                {% if credits_cibles_cycle %}
+                    {% include "inscription_aux_cours/blocks/barres_de_progression.html" %}
+                {% endif %}
                 <div class="alert alert-warning hide_print" style="display:inline-block;">
                     <i class="fa fa-info-circle" style="font-size:120%" aria-hidden="true"></i>
                     {% trans "You are not registered for any course units." %}


### PR DESCRIPTION
Pull request automatique de hotfix/OSIS-8461 vers QA