### PR TITLE
[hotfix/OSIS-8572 => QA] La progression pour les PAE avant 2015 s_affiche avec un caractère _<_ côté récapitulatif étudiant

### DIFF
--- a/inscription_aux_cours/templates/inscription_aux_cours/blocks/tableau_de_progression.html
+++ b/inscription_aux_cours/templates/inscription_aux_cours/blocks/tableau_de_progression.html
@@ -168,7 +168,7 @@
         <tr>
             <td>{% trans 'Annual programmes prior to 2015-16' %}</td>
             <td>
-                <span class="badge badge-credits-deja-acquis"><{{ tableau_de_progression.cycle.total.credits_donnees_du_passe|floatformat|default:0 }}</span>
+                <span class="badge badge-credits-deja-acquis">{{ tableau_de_progression.cycle.total.credits_donnees_du_passe|floatformat|default:0 }}</span>
             </td>
             <td>
                 <span class="badge badge-credits-deja-acquis"></span>


### PR DESCRIPTION
Pull request automatique de hotfix/OSIS-8572 vers QA