### PR TITLE
[hotfix/OSIS-9457 => MASTER] Correction des requirements pour prendre en compte les modules oubliés pour le passage à python 3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -57,3 +57,6 @@ git+https://github.com/uclouvain/osis-async.git@0.8#egg=osis_async
 -r ./osis_common/requirements.txt
 -r ./admission/requirements.txt
 -r ./dissertation/requirements.txt
+-r ./continuing_education/requirements.txt
+-r ./internship/requirements.txt
+


### PR DESCRIPTION
Pull request automatique de hotfix/OSIS-9457 vers MASTER